### PR TITLE
Add SSL support to Cloud SQL

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,11 +23,14 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -36,8 +39,13 @@ import (
 )
 
 var (
-	dump = flag.String("dump", "", "MySQL dump file")
-	dsn  = flag.String("dsn", "root:root@tcp(0.0.0.0:3306)/", "MySQL Data Source Name")
+	dump       = flag.String("dump", "", "MySQL dump file")
+	dsn        = flag.String("dsn", "root:root@tcp(0.0.0.0:3306)/", "MySQL Data Source Name")
+	enableSsl  = flag.Bool("enable_ssl", false, "Connect to MySQL with SSL")
+	sslCa      = flag.String("ssl_ca", "server-ca.pem", "MySQL Server certificate")
+	sslCert    = flag.String("ssl_cert", "client-cert.pem", "MySQL Client PEM cert file")
+	sslKey     = flag.String("ssl_key", "client-key.pem", "MySQL Client PEM key file")
+	serverName = flag.String("server_name", "project:instance", "Cloud SQL project and instance name")
 )
 
 type logLine struct {
@@ -126,6 +134,27 @@ func main() {
 		log.Fatalf("no -dump file specified")
 	}
 
+	if *enableSsl {
+		rootCertPool := x509.NewCertPool()
+		pem, err := ioutil.ReadFile(*sslCa)
+		if err != nil {
+			log.Fatalln("ioutil.Readline:", err)
+		}
+		if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
+			log.Fatal("Failed to append CA certificate PEM.")
+		}
+		clientCert := []tls.Certificate{}
+		certs, err := tls.LoadX509KeyPair(*sslCert, *sslKey)
+		if err != nil {
+			log.Fatalln("tls.LoadX509KeyPair:", err)
+		}
+		clientCert = append(clientCert, certs)
+		mysql.RegisterTLSConfig("custom", &tls.Config{
+			RootCAs:      rootCertPool,
+			Certificates: clientCert,
+			ServerName:   *serverName,
+		})
+	}
 	db, err := sql.Open("mysql", *dsn)
 	if err != nil {
 		log.Fatalln("sql.Open:", err)


### PR DESCRIPTION
Run as:
% cloudsql-import --enable_ssl --server_name project_name:instance_name \
--ssl_ca server-ca.pem --ssl_cert client-cert.pem --ssl_key client-key.pem \
--dump dump.sql --dsn 'user:pass@tcp(your_ip:3306)/?tls=custom'
